### PR TITLE
Corrected indentation to ignore unmatched quotes inside comments

### DIFF
--- a/nginxfmt.py
+++ b/nginxfmt.py
@@ -92,26 +92,38 @@ def strip_variable_template_tags(line: str) -> str:
                   flags=re.UNICODE)
 
 
-def apply_bracket_template_tags(content: str) -> str:
+def apply_bracket_template_tags(lines: list) -> list:
     """ Replaces bracket { and } with tags, so subsequent formatting is easier."""
-    result = ""
-    in_quotes = False
-    last_c = ""
+    formatted_lines = []
 
-    for c in content:
-        if (c == "\'" or c == "\"") and last_c != "\\":
-            in_quotes = reverse_in_quotes_status(in_quotes)
-        if in_quotes:
-            if c == "{":
-                result += TEMPLATE_BRACKET_OPENING_TAG
-            elif c == "}":
-                result += TEMPLATE_BRACKET_CLOSING_TAG
+    for line in lines:
+        formatted_line = ""
+        in_quotes = False
+        last_char = ""
+
+        if line.startswith('#'):
+            formatted_line += line
+            continue
+
+        for char in line:
+            if (char == "\'" or char == "\"") and last_char != "\\":
+                in_quotes = reverse_in_quotes_status(in_quotes)
+
+            if in_quotes:
+                if char == "{":
+                    formatted_line += TEMPLATE_BRACKET_OPENING_TAG
+                elif char == "}":
+                    formatted_line += TEMPLATE_BRACKET_CLOSING_TAG
+                else:
+                    formatted_line += char
             else:
-                result += c
-        else:
-            result += c
-        last_c = c
-    return result
+                formatted_line += char
+
+            last_char = char
+
+        formatted_lines.append(formatted_line)
+
+    return formatted_lines
 
 
 def reverse_in_quotes_status(status: bool) -> bool:
@@ -172,7 +184,7 @@ def perform_indentation(lines):
     indented_lines = []
     current_indent = 0
     for line in lines:
-        if not line.startswith("#") and (line.endswith('}') or line.endswith(TEMPLATE_BRACKET_CLOSING_TAG)) and current_indent > 0:
+        if not line.startswith("#") and line.endswith('}') and current_indent > 0:
             current_indent -= 1
 
         if line != "":
@@ -180,7 +192,7 @@ def perform_indentation(lines):
         else:
             indented_lines.append("")
 
-        if not line.startswith("#") and (line.endswith('{') or line.endswith(TEMPLATE_BRACKET_OPENING_TAG)):
+        if not line.startswith("#") and line.endswith('{'):
             current_indent += 1
 
     return indented_lines
@@ -188,8 +200,8 @@ def perform_indentation(lines):
 
 def format_config_contents(contents):
     """Accepts the string containing nginx configuration and returns formatted one. Adds newline at the end."""
-    contents = apply_bracket_template_tags(contents)
     lines = contents.splitlines()
+    lines = apply_bracket_template_tags(lines)
     lines = clean_lines(lines)
     lines = join_opening_bracket(lines)
     lines = perform_indentation(lines)

--- a/nginxfmt.py
+++ b/nginxfmt.py
@@ -172,7 +172,7 @@ def perform_indentation(lines):
     indented_lines = []
     current_indent = 0
     for line in lines:
-        if not line.startswith("#") and line.endswith('}') and current_indent > 0:
+        if not line.startswith("#") and (line.endswith('}') or line.endswith(TEMPLATE_BRACKET_CLOSING_TAG)) and current_indent > 0:
             current_indent -= 1
 
         if line != "":
@@ -180,7 +180,7 @@ def perform_indentation(lines):
         else:
             indented_lines.append("")
 
-        if not line.startswith("#") and line.endswith('{'):
+        if not line.startswith("#") and (line.endswith('{') or line.endswith(TEMPLATE_BRACKET_OPENING_TAG)):
             current_indent += 1
 
     return indented_lines

--- a/nginxfmt.py
+++ b/nginxfmt.py
@@ -103,23 +103,22 @@ def apply_bracket_template_tags(lines: list) -> list:
 
         if line.startswith('#'):
             formatted_line += line
-            continue
+        else:
+            for char in line:
+                if (char == "\'" or char == "\"") and last_char != "\\":
+                    in_quotes = reverse_in_quotes_status(in_quotes)
 
-        for char in line:
-            if (char == "\'" or char == "\"") and last_char != "\\":
-                in_quotes = reverse_in_quotes_status(in_quotes)
-
-            if in_quotes:
-                if char == "{":
-                    formatted_line += TEMPLATE_BRACKET_OPENING_TAG
-                elif char == "}":
-                    formatted_line += TEMPLATE_BRACKET_CLOSING_TAG
+                if in_quotes:
+                    if char == "{":
+                        formatted_line += TEMPLATE_BRACKET_OPENING_TAG
+                    elif char == "}":
+                        formatted_line += TEMPLATE_BRACKET_CLOSING_TAG
+                    else:
+                        formatted_line += char
                 else:
                     formatted_line += char
-            else:
-                formatted_line += char
 
-            last_char = char
+                last_char = char
 
         formatted_lines.append(formatted_line)
 

--- a/test_nginxfmt.py
+++ b/test_nginxfmt.py
@@ -91,17 +91,17 @@ class TestFormatter(unittest.TestCase):
                          strip_line('  lorem   ipsum   " foo  bar zip "  or \t "  dd aa  "  mi'))
 
     def test_apply_bracket_template_tags(self):
-        self.assertEqual("\"aaa___TEMPLATE_BRACKET_OPENING_TAG___dd___TEMPLATE_BRACKET_CLOSING_TAG___bbb\"",
-                         apply_bracket_template_tags("\"aaa{dd}bbb\""))
+        self.assertEqual("\"aaa___TEMPLATE_BRACKET_OPENING_TAG___dd___TEMPLATE_BRACKET_CLOSING_TAG___bbb\"".splitlines(),
+                         apply_bracket_template_tags("\"aaa{dd}bbb\"".splitlines()))
         self.assertEqual(
-            "\"aaa___TEMPLATE_BRACKET_OPENING_TAG___dd___TEMPLATE_BRACKET_CLOSING_TAG___bbb\"cc{cc}cc\"dddd___TEMPLATE_BRACKET_OPENING_TAG___eee___TEMPLATE_BRACKET_CLOSING_TAG___fff\"",
-            apply_bracket_template_tags("\"aaa{dd}bbb\"cc{cc}cc\"dddd{eee}fff\""))
+            "\"aaa___TEMPLATE_BRACKET_OPENING_TAG___dd___TEMPLATE_BRACKET_CLOSING_TAG___bbb\"cc{cc}cc\"dddd___TEMPLATE_BRACKET_OPENING_TAG___eee___TEMPLATE_BRACKET_CLOSING_TAG___fff\"".splitlines(),
+            apply_bracket_template_tags("\"aaa{dd}bbb\"cc{cc}cc\"dddd{eee}fff\"".splitlines()))
 
     def test_strip_bracket_template_tags(self):
         self.assertEqual("\"aaa{dd}bbb\"", strip_bracket_template_tags(
             "\"aaa___TEMPLATE_BRACKET_OPENING_TAG___dd___TEMPLATE_BRACKET_CLOSING_TAG___bbb\""))
-        self.assertEqual("\"aaa{dd}bbb\"cc{cc}cc\"dddd{eee}fff\"", apply_bracket_template_tags(
-            "\"aaa___TEMPLATE_BRACKET_OPENING_TAG___dd___TEMPLATE_BRACKET_CLOSING_TAG___bbb\"cc{cc}cc\"dddd___TEMPLATE_BRACKET_OPENING_TAG___eee___TEMPLATE_BRACKET_CLOSING_TAG___fff\""))
+        self.assertEqual("\"aaa{dd}bbb\"cc{cc}cc\"dddd{eee}fff\"".splitlines(), apply_bracket_template_tags(
+            "\"aaa___TEMPLATE_BRACKET_OPENING_TAG___dd___TEMPLATE_BRACKET_CLOSING_TAG___bbb\"cc{cc}cc\"dddd___TEMPLATE_BRACKET_OPENING_TAG___eee___TEMPLATE_BRACKET_CLOSING_TAG___fff\"".splitlines()))
 
     def test_variable_template_tags(self):
         self.assertEqual("foo bar ___TEMPLATE_VARIABLE_OPENING_TAG___myvar___TEMPLATE_VARIABLE_CLOSING_TAG___",


### PR DESCRIPTION
~~It seems the indentation logic is purely based on `{` and `}`, without taking the lines containing `TEMPLATE_BRACKET_OPENING_TAG` and `TEMPLATE_BRACKET_CLOSING_TAG` into consideration.~~

Unmatched quotes inside comments breaks the indentation.

Without the changes in this PR, blocks like this:

```
server {
    # My comment with an unmatched '
    location / {
        root /var/www/foo;
    }
}
```

will be transformed into this:

```
server {
    # My comment with an unmatched '
    location / {
    root /var/www/foo;
    }
}
```